### PR TITLE
Filter categories / resources when creating service/requirement

### DIFF
--- a/src/Components/Project/RequirementCreateButton.js
+++ b/src/Components/Project/RequirementCreateButton.js
@@ -13,7 +13,9 @@ import { useNotifications } from 'react-bootstrap-notify';
 
 import { Form as ResourceForm } from '../../rest-resource';
 
-import { useCategories, useResources } from '../../api';
+import { useNestedResource } from '../../rest-resource';
+
+import { useCategories, useResources, useConsortia } from '../../api';
 
 import { notificationFromError } from '../utils';
 
@@ -22,6 +24,15 @@ export const RequirementCreateButton = ({ project, service, requirements, ...pro
     const notify = useNotifications();
     const categories = useCategories();
     const resources = useResources();
+    // Get the consortium to allow us to access the related quotas
+    const consortia = useConsortia();
+    const consortium = consortia.data[project.data.consortium];
+    const quotas = useNestedResource(consortium, "quotas");
+    // Find the resources which have a quota
+    const quotaResources = [];
+    for (const j in quotas.data) {
+        quotaResources.push(quotas.data[j].data.resource)
+    }
 
     // Keep a handle on the currently selected resource
     // We use this to determine whether to show the amount/from/until fields
@@ -44,8 +55,9 @@ export const RequirementCreateButton = ({ project, service, requirements, ...pro
     // We can safely assume that the categories and resources have been initialised
     // higher up the component tree
     const category = categories.data[service.data.category];
-    // Define a filter function that selects only the resources for the category
-    const categoryResources = resource => category.data.resources.includes(resource.data.id);
+    // Define a filter function that selects only the resources for the category and that have a quota
+    const categoryResources = resource => category.data.resources.includes(resource.data.id) && quotaResources.includes(resource.data.id);
+
     // Define a function to extract the label for a resource
     // Don't forget that short_name is optional!
     const resourceLabel = resource => resource.data.short_name || resource.data.name;

--- a/src/Components/Project/ServiceCreateButton.js
+++ b/src/Components/Project/ServiceCreateButton.js
@@ -18,7 +18,6 @@ import { notificationFromError } from '../utils';
 export const ServiceCreateButton = ({ project, ...props }) => {
     const notify = useNotifications();
     const categories = useCategories();
-
     const history = useHistory();
 
     // We only need the create method from the services, so we don't need a fetch point
@@ -39,6 +38,10 @@ export const ServiceCreateButton = ({ project, ...props }) => {
         hideModal();
     };
 
+    // Define a filter function to only show categories that are public
+    const categoryIsPublic = category => category.data.is_public;
+
+    // Define a function to format the category options in the dropdown
     const formatCategoryOption = (option, { context }) => (
         context === 'menu' ? (
             <>
@@ -80,6 +83,7 @@ export const ServiceCreateButton = ({ project, ...props }) => {
                             resource={categories}
                             resourceName="category"
                             resourceNamePlural="categories"
+                            filterResources={categoryIsPublic}
                             required
                             // Use a custom label renderer
                             formatOptionLabel={formatCategoryOption}


### PR DESCRIPTION
When this is merged, the categories will all need to be given 'isPublic' status if you want them to be an option for users. I put the default as false for now.